### PR TITLE
Bugfix Empty Response

### DIFF
--- a/main.js
+++ b/main.js
@@ -227,8 +227,8 @@ function getDSMInfo(cb){
                                 'desc'       : k.desc
                             };
                         });
-                        if(cb){cb();}
                     }
+                    if(cb){cb();}
                 });
             });
         });


### PR DESCRIPTION
Empty response will stop polling.
Callback must be called even if the res is empty

See #22 for details